### PR TITLE
Update Footer.vue: Change Canon-2 Github link

### DIFF
--- a/components/Layout/Footer.vue
+++ b/components/Layout/Footer.vue
@@ -134,7 +134,7 @@
               <UIFooterTitle>Testnets</UIFooterTitle>
               <ul>
                 <UIFooterLink
-                  to="https://github.com/umee-network/umee/tree/canon-2/networks/canon-2"
+                  to="https://github.com/umee-network/umee/tree/main/networks/canon-2"
                   >Canon-2 Github</UIFooterLink
                 >
                 <UIFooterLink to="https://canon.umee.cc/"


### PR DESCRIPTION

There is a broken link in footer under Testnets section. Canon-2 Github link is pointing to a github branch that is gone.

Related to #61  